### PR TITLE
@craigspaeth => Dont use Math.abs

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -32,7 +32,7 @@ fillwidth = ($list, targetHeight, done, apply, gutterSize, dontResizeUp) ->
     imgsWidth = ->
       _.reduce _.map(imgs, (i) -> i.width), (m, n) -> m + n
     widthDiff = ->
-      Math.abs $list.width() - imgsWidth()
+      $list.width() - imgsWidth()
     resizeHeight = (img, dir) ->
       img.width += (img.width / img.height) * dir
       img.height += dir

--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@
           });
         };
         widthDiff = function() {
-          return Math.abs($list.width() - imgsWidth());
+          return $list.width() - imgsWidth();
         };
         resizeHeight = function(img, dir) {
           img.width += (img.width / img.height) * dir;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jquery-fillwidth-lite",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Lines up a single row of images to fit their container. ",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Basically, `Math.abs` isn't necessary here. It's possible to get into a state where adjusting the pixel height by 1px of a row of images, changes the width by such that `Math.abs` keeps it as `> 1`, and thus the fill width algorithm gives up.

Since we only ever do `widthDiff() < 1`, I think the `Math.abs` is a bug/not needed.
